### PR TITLE
feat: build phpredis with LZ4 and Zstd compression support (8.3/8.4/8.5)

### DIFF
--- a/8/8.3/Dockerfile.apache
+++ b/8/8.3/Dockerfile.apache
@@ -41,7 +41,10 @@ RUN apt-get -y update && apt-get -y upgrade && ACCEPT_EULA=Y && apt-get install 
     util-linux \
     gosu \
     jq \
-    redis-tools && \
+    redis-tools \
+    vim \
+    liblz4-dev \
+    libzstd-dev && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -58,8 +61,9 @@ RUN docker-php-ext-install pcntl
 RUN docker-php-ext-install sockets
 RUN printf "log_errors = On \nerror_log = /dev/stderr\n" > /usr/local/etc/php/conf.d/php-logs.ini
 
-# Install redis extension
-RUN pecl install redis && docker-php-ext-enable redis
+# Install redis extension with LZ4 and Zstd compression support
+RUN pecl install --configureoptions 'enable-redis-lz4="yes" with-liblz4="yes" enable-redis-zstd="yes"' redis \
+    && docker-php-ext-enable redis
 
 # Apache settings
 COPY 8/8.3/etc/apache2/conf-enabled/host.conf /etc/apache2/conf-enabled/host.conf

--- a/8/8.3/Dockerfile.cli
+++ b/8/8.3/Dockerfile.cli
@@ -42,7 +42,10 @@ RUN apt-get -y update && apt-get -y upgrade && ACCEPT_EULA=Y && apt-get install 
     util-linux \
     gosu \
     jq \
-    redis-tools && \
+    redis-tools \
+    vim \
+    liblz4-dev \
+    libzstd-dev && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -59,8 +62,9 @@ RUN docker-php-ext-install pcntl
 RUN docker-php-ext-install sockets
 RUN printf "log_errors = On \nerror_log = /dev/stderr\n" > /usr/local/etc/php/conf.d/php-logs.ini
 
-# Install redis extension
-RUN pecl install redis && docker-php-ext-enable redis
+# Install redis extension with LZ4 and Zstd compression support
+RUN pecl install --configureoptions 'enable-redis-lz4="yes" with-liblz4="yes" enable-redis-zstd="yes"' redis \
+    && docker-php-ext-enable redis
 
 # PHP settings
 COPY 8/8.3/etc/php/production.ini /usr/local/etc/php/conf.d/

--- a/8/8.4/Dockerfile.apache
+++ b/8/8.4/Dockerfile.apache
@@ -41,7 +41,10 @@ RUN apt-get -y update && apt-get -y upgrade && ACCEPT_EULA=Y && apt-get install 
     util-linux \
     gosu \
     jq \
-    redis-tools && \
+    redis-tools \
+    vim \
+    liblz4-dev \
+    libzstd-dev && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -58,8 +61,9 @@ RUN docker-php-ext-install pcntl
 RUN docker-php-ext-install sockets
 RUN printf "log_errors = On \nerror_log = /dev/stderr\n" > /usr/local/etc/php/conf.d/php-logs.ini
 
-# Install redis extension
-RUN pecl install redis && docker-php-ext-enable redis
+# Install redis extension with LZ4 and Zstd compression support
+RUN pecl install --configureoptions 'enable-redis-lz4="yes" with-liblz4="yes" enable-redis-zstd="yes"' redis \
+    && docker-php-ext-enable redis
 
 # Apache settings
 COPY 8/8.4/etc/apache2/conf-enabled/host.conf /etc/apache2/conf-enabled/host.conf

--- a/8/8.4/Dockerfile.cli
+++ b/8/8.4/Dockerfile.cli
@@ -42,7 +42,10 @@ RUN apt-get -y update && apt-get -y upgrade && ACCEPT_EULA=Y && apt-get install 
     util-linux \
     gosu \
     jq \
-    redis-tools && \
+    redis-tools \
+    vim \
+    liblz4-dev \
+    libzstd-dev && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -59,8 +62,9 @@ RUN docker-php-ext-install pcntl
 RUN docker-php-ext-install sockets
 RUN printf "log_errors = On \nerror_log = /dev/stderr\n" > /usr/local/etc/php/conf.d/php-logs.ini
 
-# Install redis extension
-RUN pecl install redis && docker-php-ext-enable redis
+# Install redis extension with LZ4 and Zstd compression support
+RUN pecl install --configureoptions 'enable-redis-lz4="yes" with-liblz4="yes" enable-redis-zstd="yes"' redis \
+    && docker-php-ext-enable redis
 
 # PHP settings
 COPY 8/8.4/etc/php/production.ini /usr/local/etc/php/conf.d/

--- a/8/8.5/Dockerfile.apache
+++ b/8/8.5/Dockerfile.apache
@@ -41,7 +41,10 @@ RUN apt-get -y update && apt-get -y upgrade && ACCEPT_EULA=Y && apt-get install 
     util-linux \
     gosu \
     jq \
-    redis-tools && \
+    redis-tools \
+    vim \
+    liblz4-dev \
+    libzstd-dev && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -58,8 +61,9 @@ RUN docker-php-ext-install pcntl
 RUN docker-php-ext-install sockets
 RUN printf "log_errors = On \nerror_log = /dev/stderr\n" > /usr/local/etc/php/conf.d/php-logs.ini
 
-# Install redis extension
-RUN pecl install redis && docker-php-ext-enable redis
+# Install redis extension with LZ4 and Zstd compression support
+RUN pecl install --configureoptions 'enable-redis-lz4="yes" with-liblz4="yes" enable-redis-zstd="yes"' redis \
+    && docker-php-ext-enable redis
 
 # Apache settings
 COPY 8/8.5/etc/apache2/conf-enabled/host.conf /etc/apache2/conf-enabled/host.conf

--- a/8/8.5/Dockerfile.cli
+++ b/8/8.5/Dockerfile.cli
@@ -42,7 +42,10 @@ RUN apt-get -y update && apt-get -y upgrade && ACCEPT_EULA=Y && apt-get install 
     util-linux \
     gosu \
     jq \
-    redis-tools && \
+    redis-tools \
+    vim \
+    liblz4-dev \
+    libzstd-dev && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -59,8 +62,9 @@ RUN docker-php-ext-install pcntl
 RUN docker-php-ext-install sockets
 RUN printf "log_errors = On \nerror_log = /dev/stderr\n" > /usr/local/etc/php/conf.d/php-logs.ini
 
-# Install redis extension
-RUN pecl install redis && docker-php-ext-enable redis
+# Install redis extension with LZ4 and Zstd compression support
+RUN pecl install --configureoptions 'enable-redis-lz4="yes" with-liblz4="yes" enable-redis-zstd="yes"' redis \
+    && docker-php-ext-enable redis
 
 # PHP settings
 COPY 8/8.5/etc/php/production.ini /usr/local/etc/php/conf.d/


### PR DESCRIPTION
## Summary

Rebuilds the `phpredis` extension across PHP 8.3, 8.4, and 8.5 (both `apache` and `cli` variants) with LZ4 and Zstd compression support compiled in.

**Changes per Dockerfile (×6):**
- Add `liblz4-dev` and `libzstd-dev` system packages
- Add `vim` (useful for in-container debugging)
- Replace `pecl install redis` with `pecl install --configureoptions 'enable-redis-lz4="yes" with-liblz4="yes" enable-redis-zstd="yes"' redis`

## Compression is NOT enabled by default

This PR only makes compression *available* at the PHP level. Enabling it requires:
1. A coordinated deploy of **all** containers simultaneously (apache + worker + realtime)
2. An immediate cache flush after deploy — existing uncompressed entries are unreadable by a compressed client

The config line (`'compression' => \Redis::COMPRESSION_LZ4`) is already written and commented out in the application config, waiting for a scheduled maintenance window.

## Why LZ4

The dominant Redis bandwidth consumer is the `flarum:settings` key (~154 KB of serialised PHP). LZ4 compression is expected to reduce this to ~15–25 KB — a ~6–10× reduction — with negligible CPU cost. At current traffic levels this would bring Redis egress from ~10–15 Mbps (post settings-memory-cache fix) down to ~2–3 Mbps.