### PR TITLE
feat: PHP 8.3 FPM images with Apache mpm_event for Flarum

### DIFF
--- a/.github/workflows/docker-image-fpm.yml
+++ b/.github/workflows/docker-image-fpm.yml
@@ -1,0 +1,66 @@
+name: Docker Image CI - FPM
+
+on:
+  workflow_dispatch:
+
+jobs:
+  # Build FPM apache and cli images in parallel (8.3 only)
+  build_fpm_apache_and_cli:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        config:
+          - {dockerfile_suffix: 'apache', tag_suffix: 'latest'}
+          - {dockerfile_suffix: 'cli', tag_suffix: 'cli'}
+    steps:
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+      with:
+        platforms: linux/amd64,linux/arm64
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKER_HUB_USERNAME }}
+        password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+    - uses: actions/checkout@v4
+    - name: Build and Push FPM Docker image
+      run: |
+        docker buildx build . \
+          --progress=plain \
+          --platform linux/amd64,linux/arm64 \
+          --file fpm/8.3/Dockerfile.${{ matrix.config.dockerfile_suffix }} \
+          --tag ianmgg/php83fpm:${{ matrix.config.tag_suffix }} \
+          --push
+
+  # Build FPM dev images which depend on the base FPM images
+  build_fpm_dev:
+    needs: build_fpm_apache_and_cli
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        config:
+          - {dockerfile_suffix: 'apache.dev', tag_suffix: 'dev'}
+          - {dockerfile_suffix: 'cli.dev', tag_suffix: 'cli-dev'}
+    steps:
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+      with:
+        platforms: linux/amd64,linux/arm64
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKER_HUB_USERNAME }}
+        password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+    - uses: actions/checkout@v4
+    - name: Build and Push FPM dev Docker image
+      run: |
+        docker buildx build . \
+          --progress=plain \
+          --platform linux/amd64,linux/arm64 \
+          --file fpm/8.3/Dockerfile.${{ matrix.config.dockerfile_suffix }} \
+          --tag ianmgg/php83fpm:${{ matrix.config.tag_suffix }} \
+          --push

--- a/fpm/8.3/Dockerfile.apache
+++ b/fpm/8.3/Dockerfile.apache
@@ -1,0 +1,103 @@
+FROM php:8.3-fpm
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Setup Debian packages
+RUN apt-get -y update && apt-get -y upgrade && ACCEPT_EULA=Y && apt-get install -y \
+    apache2 \
+    procps \
+    cron \
+    unzip \
+    libfreetype6-dev \
+    libjpeg62-turbo-dev \
+    libzip-dev \
+    libxml2-dev \
+    libxslt-dev \
+    libssl-dev \
+    zlib1g-dev \
+    libpng-dev \
+    libwebp-dev \
+    libjpeg-dev \
+    libonig-dev \
+    libicu-dev \
+    apt-file \
+    wget \
+    gnupg \
+    gnupg2 \
+    zip \
+    git \
+    curl \
+    gcc \
+    g++ \
+    autoconf \
+    libc-dev \
+    pkg-config \
+    iputils-ping \
+    netcat-openbsd \
+    default-mysql-client \
+    util-linux \
+    gosu \
+    jq \
+    redis-tools \
+    vim \
+    liblz4-dev \
+    libzstd-dev && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# PHP extensions, separated for QEMU build purposes
+RUN docker-php-ext-configure gd --with-freetype --with-webp --with-jpeg
+RUN docker-php-ext-install gd
+RUN docker-php-ext-install calendar
+RUN docker-php-ext-install intl
+RUN docker-php-ext-install pdo_mysql
+RUN docker-php-ext-install xml
+RUN docker-php-ext-install zip
+RUN docker-php-ext-install exif
+RUN docker-php-ext-install pcntl
+RUN docker-php-ext-install sockets
+RUN printf "log_errors = On \nerror_log = /dev/stderr\n" > /usr/local/etc/php/conf.d/php-logs.ini
+
+# Install redis extension with LZ4 and Zstd compression support
+RUN pecl install --configureoptions 'enable-redis-lz4="yes" with-liblz4="yes" enable-redis-zstd="yes"' redis \
+    && docker-php-ext-enable redis
+
+# PHP-FPM pool config (Unix socket)
+COPY fpm/8.3/etc/php-fpm/www.conf /usr/local/etc/php-fpm.d/www.conf
+
+# Apache settings
+COPY fpm/8.3/etc/apache2/conf-enabled/host.conf /etc/apache2/conf-enabled/host.conf
+COPY fpm/8.3/etc/apache2/apache2.conf /etc/apache2/apache2.conf
+COPY fpm/8.3/etc/apache2/sites-enabled/000-default.conf /etc/apache2/sites-enabled/000-default.conf
+
+# PHP settings - Flarum tuned OPcache
+COPY fpm/8.3/etc/php/flarum.ini /usr/local/etc/php/conf.d/flarum.ini
+
+# Composer
+COPY fpm/8.3/etc/ssh/* /usr/local/ssh/
+RUN mkdir -p /usr/local/ssh && \
+    sh /usr/local/ssh/install-composer.sh && \
+    mv composer.phar /usr/local/bin/composer
+
+# Apache modules: disable prefork, enable event + proxy_fcgi
+RUN a2dismod mpm_prefork && \
+    a2enmod mpm_event proxy_fcgi setenvif rewrite deflate brotli headers ssl cache expires && \
+    sed -i 's/Listen 80/Listen 8080/g' /etc/apache2/ports.conf && \
+    mkdir -p /var/lock/apache2 /var/run/apache2 && \
+    chmod g+w /var/log/apache2 && \
+    chmod 777 /var/lock/apache2 && \
+    chmod 777 /var/run/apache2 && \
+    echo "<?php echo phpinfo(); ?>" > /var/www/html/index.php
+
+# Apache configuration test
+RUN apachectl configtest
+
+# Startup script: launch PHP-FPM as daemon, then Apache in foreground
+RUN printf '#!/bin/sh\nset -e\nphp-fpm -D\nexec apache2-foreground\n' > /usr/local/bin/startup && \
+    chmod +x /usr/local/bin/startup
+
+EXPOSE 8080
+
+ENV PROVISION_CONTEXT="production"
+
+CMD ["startup"]

--- a/fpm/8.3/Dockerfile.apache.dev
+++ b/fpm/8.3/Dockerfile.apache.dev
@@ -1,0 +1,16 @@
+# Use the FPM PHP 8.3 image as the base image
+FROM ianmgg/php83fpm:latest
+
+### DEV ENVIRONMENT SPECIFIC ###
+################################
+ENV PROVISION_CONTEXT="development"
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install xdebug, enable it, and configure the log
+RUN pecl install xdebug-3.4.7 && \
+    docker-php-ext-enable xdebug && \
+    touch /var/log/xdebug.log && \
+    chmod 777 /var/log/xdebug.log
+
+# Configure PHP - swap flarum.ini for dev variant (OPcache disabled, errors on)
+COPY fpm/8.3/etc/php/flarum-dev.ini /usr/local/etc/php/conf.d/flarum.ini

--- a/fpm/8.3/Dockerfile.cli
+++ b/fpm/8.3/Dockerfile.cli
@@ -1,0 +1,72 @@
+FROM php:8.3-cli
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Setup Debian packages
+RUN apt-get -y update && apt-get -y upgrade && ACCEPT_EULA=Y && apt-get install -y \
+    procps \
+    cron \
+    unzip \
+    libfreetype6-dev \
+    libjpeg62-turbo-dev \
+    libzip-dev \
+    libxml2-dev \
+    libxslt-dev \
+    libssl-dev \
+    zlib1g-dev \
+    libpng-dev \
+    libwebp-dev \
+    libjpeg-dev \
+    libonig-dev \
+    libicu-dev \
+    apt-file \
+    wget \
+    gnupg \
+    gnupg2 \
+    zip \
+    git \
+    curl \
+    gcc \
+    g++ \
+    autoconf \
+    libc-dev \
+    pkg-config \
+    iputils-ping \
+    netcat-openbsd \
+    default-mysql-client \
+    util-linux \
+    gosu \
+    jq \
+    redis-tools \
+    vim \
+    liblz4-dev \
+    libzstd-dev && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# PHP extensions, separated for QEMU build purposes
+RUN docker-php-ext-configure gd --with-freetype --with-webp --with-jpeg
+RUN docker-php-ext-install gd
+RUN docker-php-ext-install calendar
+RUN docker-php-ext-install intl
+RUN docker-php-ext-install pdo_mysql
+RUN docker-php-ext-install xml
+RUN docker-php-ext-install zip
+RUN docker-php-ext-install exif
+RUN docker-php-ext-install pcntl
+RUN docker-php-ext-install sockets
+RUN printf "log_errors = On \nerror_log = /dev/stderr\n" > /usr/local/etc/php/conf.d/php-logs.ini
+
+# Install redis extension with LZ4 and Zstd compression support
+RUN pecl install --configureoptions 'enable-redis-lz4="yes" with-liblz4="yes" enable-redis-zstd="yes"' redis \
+    && docker-php-ext-enable redis
+
+# PHP settings - Flarum tuned OPcache
+COPY fpm/8.3/etc/php/flarum.ini /usr/local/etc/php/conf.d/flarum.ini
+
+# Composer
+COPY fpm/8.3/etc/ssh/* /usr/local/ssh/
+RUN sh /usr/local/ssh/install-composer.sh && \
+    mv composer.phar /usr/local/bin/composer
+
+ENV PROVISION_CONTEXT="cli"

--- a/fpm/8.3/Dockerfile.cli.dev
+++ b/fpm/8.3/Dockerfile.cli.dev
@@ -1,0 +1,16 @@
+# Use the FPM PHP 8.3 CLI image as the base image
+FROM ianmgg/php83fpm:cli
+
+### DEV ENVIRONMENT SPECIFIC ###
+################################
+ENV PROVISION_CONTEXT="development"
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install xdebug, enable it, and configure the log
+RUN pecl install xdebug-3.4.7 && \
+    docker-php-ext-enable xdebug && \
+    touch /var/log/xdebug.log && \
+    chmod 777 /var/log/xdebug.log
+
+# Configure PHP - swap flarum.ini for dev variant (OPcache disabled, errors on)
+COPY fpm/8.3/etc/php/flarum-dev.ini /usr/local/etc/php/conf.d/flarum.ini

--- a/fpm/8.3/README.md
+++ b/fpm/8.3/README.md
@@ -1,0 +1,77 @@
+## PHP 8.3 FPM Images
+
+PHP 8.3 images built on `php:8.3-fpm` (rolling, not pinned to a Debian release).
+Apache runs in **mpm_event** mode and proxies to PHP-FPM over a Unix socket for better concurrency than the traditional mod_php / mpm_prefork setup.
+
+OPcache is tuned for [Flarum](https://flarum.org/) — large composer autoloader, many files, JIT enabled.
+
+---
+
+### Images
+
+| Image | Tag | Dockerfile | Description |
+|-------|-----|------------|-------------|
+| `ianmgg/php83fpm` | `latest` | `Dockerfile.apache` | Production web image. Apache mpm_event + PHP-FPM. OPcache on, JIT enabled. |
+| `ianmgg/php83fpm` | `dev` | `Dockerfile.apache.dev` | Development web image. Extends `latest`. Adds Xdebug, OPcache disabled. |
+| `ianmgg/php83fpm` | `cli` | `Dockerfile.cli` | CLI image for queue workers and websocket servers (Horizon, Reverb). OPcache enabled for long-running processes. |
+| `ianmgg/php83fpm` | `cli-dev` | `Dockerfile.cli.dev` | Development CLI image. Extends `cli`. Adds Xdebug, OPcache disabled. |
+
+---
+
+### Building locally
+
+All commands are run from the **repository root** (the build context must be the repo root so `COPY fpm/8.3/...` paths resolve correctly).
+
+```bash
+# Production web image
+docker buildx build -f fpm/8.3/Dockerfile.apache -t ianmgg/php83fpm:latest .
+
+# Development web image (requires latest to be built or available on Docker Hub first)
+docker buildx build -f fpm/8.3/Dockerfile.apache.dev -t ianmgg/php83fpm:dev .
+
+# CLI image
+docker buildx build -f fpm/8.3/Dockerfile.cli -t ianmgg/php83fpm:cli .
+
+# Development CLI image (requires cli to be built or available on Docker Hub first)
+docker buildx build -f fpm/8.3/Dockerfile.cli.dev -t ianmgg/php83fpm:cli-dev .
+```
+
+To build for a specific platform:
+
+```bash
+docker buildx build --platform linux/amd64 -f fpm/8.3/Dockerfile.apache -t ianmgg/php83fpm:latest .
+docker buildx build --platform linux/arm64 -f fpm/8.3/Dockerfile.apache -t ianmgg/php83fpm:latest .
+```
+
+---
+
+### Architecture
+
+```
+┌─────────────────────────────┐
+│  Apache (mpm_event :8080)   │
+│  mod_proxy_fcgi             │
+└────────────┬────────────────┘
+             │ Unix socket
+             │ /var/run/php-fpm.sock
+┌────────────▼────────────────┐
+│  PHP-FPM 8.3                │
+│  OPcache + JIT              │
+└─────────────────────────────┘
+```
+
+Both processes start via `/usr/local/bin/startup` (`php-fpm -D` then `apache2-foreground`).
+
+---
+
+### OPcache settings (production)
+
+| Setting | Value | Reason |
+|---------|-------|--------|
+| `memory_consumption` | 256MB | Flarum + extensions have a large file set |
+| `max_accelerated_files` | 20000 | Covers Flarum core + composer dependencies |
+| `interned_strings_buffer` | 32MB | Reduces string duplication across cached files |
+| `validate_timestamps` | 0 | No file stat on each request — restart FPM after deploys |
+| `jit` | 1255 | Tracing JIT, best for repeated request patterns |
+| `jit_buffer_size` | 128MB | |
+| `enable_cli` | 1 | Benefits Horizon workers and websocket servers |

--- a/fpm/8.3/etc/apache2/apache2.conf
+++ b/fpm/8.3/etc/apache2/apache2.conf
@@ -1,0 +1,228 @@
+# This is the main Apache server configuration file.  It contains the
+# configuration directives that give the server its instructions.
+# See http://httpd.apache.org/docs/2.4/ for detailed information about
+# the directives and /usr/share/doc/apache2/README.Debian about Debian specific
+# hints.
+#
+#
+# Summary of how the Apache 2 configuration works in Debian:
+# The Apache 2 web server configuration in Debian is quite different to
+# upstream's suggested way to configure the web server. This is because Debian's
+# default Apache2 installation attempts to make adding and removing modules,
+# virtual hosts, and extra configuration directives as flexible as possible, in
+# order to make automating the changes and administering the server as easy as
+# possible.
+
+# It is split into several files forming the configuration hierarchy outlined
+# below, all located in the /etc/apache2/ directory:
+#
+#	/etc/apache2/
+#	|-- apache2.conf
+#	|	`--  ports.conf
+#	|-- mods-enabled
+#	|	|-- *.load
+#	|	`-- *.conf
+#	|-- conf-enabled
+#	|	`-- *.conf
+# 	`-- sites-enabled
+#	 	`-- *.conf
+#
+#
+# * apache2.conf is the main configuration file (this file). It puts the pieces
+#   together by including all remaining configuration files when starting up the
+#   web server.
+#
+# * ports.conf is always included from the main configuration file. It is
+#   supposed to determine listening ports for incoming connections which can be
+#   customized anytime.
+#
+# * Configuration files in the mods-enabled/, conf-enabled/ and sites-enabled/
+#   directories contain particular configuration snippets which manage modules,
+#   global configuration fragments, or virtual host configurations,
+#   respectively.
+#
+#   They are activated by symlinking available configuration files from their
+#   respective *-available/ counterparts. These should be managed by using our
+#   helpers a2enmod/a2dismod, a2ensite/a2dissite and a2enconf/a2disconf. See
+#   their respective man pages for detailed information.
+#
+# * The binary is called apache2. Due to the use of environment variables, in
+#   the default configuration, apache2 needs to be started/stopped with
+#   /etc/init.d/apache2 or apache2ctl. Calling /usr/bin/apache2 directly will not
+#   work with the default configuration.
+
+
+# Global configuration
+#
+
+#
+# ServerRoot: The top of the directory tree under which the server's
+# configuration, error, and log files are kept.
+#
+# NOTE!  If you intend to place this on an NFS (or otherwise network)
+# mounted filesystem then please read the Mutex documentation (available
+# at <URL:http://httpd.apache.org/docs/2.4/mod/core.html#mutex>);
+# you will save yourself a lot of trouble.
+#
+# Do NOT add a slash at the end of the directory path.
+#
+#ServerRoot "/etc/apache2"
+
+#
+# The accept serialization lock file MUST BE STORED ON A LOCAL DISK.
+#
+#Mutex file:${APACHE_LOCK_DIR} default
+
+#
+# The directory where shm and other runtime files will be stored.
+#
+
+DefaultRuntimeDir ${APACHE_RUN_DIR}
+
+#
+# PidFile: The file in which the server should record its process
+# identification number when it starts.
+# This needs to be set in /etc/apache2/envvars
+#
+PidFile ${APACHE_PID_FILE}
+
+#
+# Timeout: The number of seconds before receives and sends time out.
+#
+Timeout 300
+
+#
+# KeepAlive: Whether or not to allow persistent connections (more than
+# one request per connection). Set to "Off" to deactivate.
+#
+KeepAlive On
+
+#
+# MaxKeepAliveRequests: The maximum number of requests to allow
+# during a persistent connection. Set to 0 to allow an unlimited amount.
+# We recommend you leave this number high, for maximum performance.
+#
+MaxKeepAliveRequests 100
+
+#
+# KeepAliveTimeout: Number of seconds to wait for the next request from the
+# same client on the same connection.
+#
+KeepAliveTimeout 5
+
+
+# These need to be set in /etc/apache2/envvars
+User ${APACHE_RUN_USER}
+Group ${APACHE_RUN_GROUP}
+
+#
+# HostnameLookups: Log the names of clients or just their IP addresses
+# e.g., www.apache.org (on) or 204.62.129.132 (off).
+# The default is off because it'd be overall better for the net if people
+# had to knowingly turn this feature on, since enabling it means that
+# each client request will result in AT LEAST one lookup request to the
+# nameserver.
+#
+HostnameLookups Off
+
+# ErrorLog: The location of the error log file.
+# If you do not specify an ErrorLog directive within a <VirtualHost>
+# container, error messages relating to that virtual host will be
+# logged here.  If you *do* define an error logfile for a <VirtualHost>
+# container, that host's errors will be logged there and not here.
+#
+ErrorLog ${APACHE_LOG_DIR}/error.log
+
+#
+# LogLevel: Control the severity of messages logged to the error_log.
+# Available values: trace8, ..., trace1, debug, info, notice, warn,
+# error, crit, alert, emerg.
+# It is also possible to configure the log level for particular modules, e.g.
+# "LogLevel info ssl:warn"
+#
+LogLevel warn
+
+# Include module configuration:
+IncludeOptional mods-enabled/*.load
+IncludeOptional mods-enabled/*.conf
+
+# Include list of ports to listen on
+Include ports.conf
+
+
+# Sets the default security model of the Apache2 HTTPD server. It does
+# not allow access to the root filesystem outside of /usr/share and /var/www.
+# The former is used by web applications packaged in Debian,
+# the latter may be used for local directories served by the web server. If
+# your system is serving content from a sub-directory in /srv you must allow
+# access here, or in any related virtual host.
+<Directory />
+	Options FollowSymLinks
+	AllowOverride None
+	Require all denied
+</Directory>
+
+<Directory /usr/share>
+	AllowOverride None
+	Require all granted
+</Directory>
+
+<Directory /var/www/>
+	Options Indexes FollowSymLinks
+	AllowOverride None
+	Require all granted
+</Directory>
+
+#<Directory /srv/>
+#	Options Indexes FollowSymLinks
+#	AllowOverride None
+#	Require all granted
+#</Directory>
+
+
+
+
+# AccessFileName: The name of the file to look for in each directory
+# for additional configuration directives.  See also the AllowOverride
+# directive.
+#
+AccessFileName .htaccess
+
+#
+# The following lines prevent .htaccess and .htpasswd files from being
+# viewed by Web clients.
+#
+<FilesMatch "^\.ht">
+	Require all denied
+</FilesMatch>
+
+
+#
+# The following directives define some format nicknames for use with
+# a CustomLog directive.
+#
+# These deviate from the Common Log Format definitions in that they use %O
+# (the actual bytes sent including headers) instead of %b (the size of the
+# requested file), because the latter makes it impossible to detect partial
+# requests.
+#
+# Note that the use of %{X-Forwarded-For}i instead of %h is not recommended.
+# Use mod_remoteip instead.
+#
+LogFormat "%v:%p %h %l %u %t \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\"" vhost_combined
+LogFormat "%h %l %u %t \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\"" combined
+LogFormat "%h %l %u %t \"%r\" %>s %O" common
+LogFormat "%{Referer}i -> %U" referer
+LogFormat "%{User-agent}i" agent
+LogFormat "%{%a %m/%d/%Y @ %I:%M:%S.}t%{msec_frac}t %{%p %Z}t %h (%{X-Forwarded-For}i) > %v:%p \"%r\" %I %D %>s %b %k %L \"%{Referer}i\" \"%{User-Agent}i\" %u %{User}C %{SessionTracker}C" enhanced
+
+# Include of directories ignores editors' and dpkg's backup files,
+# see README.Debian for details.
+
+# Include generic snippets of statements
+IncludeOptional conf-enabled/*.conf
+
+# Include the virtual host configurations:
+IncludeOptional sites-enabled/*.conf
+
+# vim: syntax=apache ts=4 sw=4 sts=4 sr noet

--- a/fpm/8.3/etc/apache2/sites-enabled/000-default.conf
+++ b/fpm/8.3/etc/apache2/sites-enabled/000-default.conf
@@ -1,0 +1,18 @@
+<VirtualHost *:8080>
+	ServerAdmin webmaster@localhost
+	DocumentRoot /var/www/html
+
+	<Directory /var/www/html>
+		Options FollowSymLinks
+		AllowOverride All
+		Require all granted
+	</Directory>
+
+	# Route all .php requests to PHP-FPM via Unix socket
+	<FilesMatch \.php$>
+		SetHandler "proxy:unix:/var/run/php-fpm.sock|fcgi://localhost"
+	</FilesMatch>
+
+	ErrorLog ${APACHE_LOG_DIR}/error.log
+	CustomLog ${APACHE_LOG_DIR}/access.log enhanced
+</VirtualHost>

--- a/fpm/8.3/etc/php-fpm/www.conf
+++ b/fpm/8.3/etc/php-fpm/www.conf
@@ -1,0 +1,24 @@
+[www]
+
+user = www-data
+group = www-data
+
+; Unix socket - faster than TCP for same-host communication
+listen = /var/run/php-fpm.sock
+listen.owner = www-data
+listen.group = www-data
+listen.mode = 0660
+
+; Pass host environment variables through to PHP scripts
+clear_env = no
+
+pm = dynamic
+pm.max_children = 10
+pm.start_servers = 2
+pm.min_spare_servers = 1
+pm.max_spare_servers = 3
+pm.max_requests = 500
+
+; Log slow requests (> 10s) to help spot Flarum bottlenecks
+slowlog = /var/log/php-fpm-slow.log
+request_slowlog_timeout = 10s

--- a/fpm/8.3/etc/php/flarum-dev.ini
+++ b/fpm/8.3/etc/php/flarum-dev.ini
@@ -1,0 +1,36 @@
+; -------------------------------------
+; FLARUM DEVELOPMENT configuration
+; -------------------------------------
+
+display_errors = 1
+
+short_open_tag    = On
+variables_order   = 'GPCS'
+request_order     = 'GP'
+
+allow_url_fopen   = On
+allow_url_include = Off
+
+memory_limit        = 256M
+max_execution_time  = 300
+max_input_time      = 300
+post_max_size       = 50M
+upload_max_filesize = 50M
+max_input_vars      = 5000
+
+expose_php          = Off
+
+date.timezone = Europe/London
+
+mysql.default_host = mysql
+mysqli.default_host = mysql
+
+; Zend OPCache - disabled for development so code changes are picked up immediately
+opcache.enable = 0
+opcache.memory_consumption = 256
+opcache.interned_strings_buffer = 32
+opcache.max_accelerated_files = 20000
+opcache.fast_shutdown = 1
+opcache.enable_cli = 0
+opcache.validate_timestamps = 1
+opcache.revalidate_freq = 0

--- a/fpm/8.3/etc/php/flarum.ini
+++ b/fpm/8.3/etc/php/flarum.ini
@@ -1,0 +1,48 @@
+; -------------------------------------
+; FLARUM PRODUCTION configuration
+; -------------------------------------
+
+display_errors = 0
+
+short_open_tag    = On
+variables_order   = 'GPCS'
+request_order     = 'GP'
+
+allow_url_fopen   = On
+allow_url_include = Off
+
+memory_limit        = 256M
+max_execution_time  = 300
+max_input_time      = 300
+post_max_size       = 50M
+upload_max_filesize = 50M
+max_input_vars      = 5000
+
+expose_php          = Off
+
+date.timezone = Europe/London
+
+mysql.default_host = mysql
+mysqli.default_host = mysql
+
+; Zend OPCache - tuned for Flarum
+; Flarum + extensions load a large number of files via Composer autoloader
+opcache.enable = 1
+opcache.memory_consumption = 256
+opcache.interned_strings_buffer = 32
+opcache.max_accelerated_files = 20000
+opcache.fast_shutdown = 1
+opcache.enable_cli = 1
+
+; Production: disable timestamp validation for maximum performance.
+; Restart PHP-FPM to pick up code changes after deploys.
+opcache.validate_timestamps = 0
+opcache.revalidate_freq = 0
+
+; JIT compilation (tracing mode - best for request-based workloads)
+opcache.jit = 1255
+opcache.jit_buffer_size = 128M
+
+; XDebug (disabled in production)
+xdebug.remote_enable           = 0
+xdebug.remote_connect_back     = off

--- a/fpm/8.3/etc/ssh/install-composer.sh
+++ b/fpm/8.3/etc/ssh/install-composer.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# EXPECTED_CHECKSUM="$(php -r 'copy("https://composer.github.io/installer.sig", "php://stdout");')"
+php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+# ACTUAL_CHECKSUM="$(php -r "echo hash_file('sha384', 'composer-setup.php');")"
+
+# if [ "$EXPECTED_CHECKSUM" != "$ACTUAL_CHECKSUM" ]
+# then
+#     >&2 echo 'ERROR: Invalid installer checksum'
+#     rm composer-setup.php
+#     exit 1
+# fi
+
+php composer-setup.php --quiet
+RESULT=$?
+rm composer-setup.php
+exit $RESULT


### PR DESCRIPTION
## Summary

- New image set under `fpm/8.3/` based on `php:8.3-fpm` (rolling tag, not pinned to a Debian release)
- Apache runs in **mpm_event** mode with PHP-FPM over a Unix socket, replacing the legacy mod_php/mpm_prefork approach
- OPcache tuned for Flarum: 256MB memory, 20k accelerated files, JIT tracing mode, `validate_timestamps=0`
- `opcache.enable_cli=1` for long-running CLI processes (Horizon, Reverb)
- mod_brotli enabled alongside deflate
- Separate GitHub Actions workflow (`docker-image-fpm.yml`) — **manual trigger only** for now

## Images

| Tag | Description |
|-----|-------------|
| `ianmgg/php83fpm:latest` | Production web — Apache mpm_event + PHP-FPM |
| `ianmgg/php83fpm:cli` | CLI — queue workers, websocket servers |
| `ianmgg/php83fpm:dev` | Dev web — extends latest, adds Xdebug, OPcache off |
| `ianmgg/php83fpm:cli-dev` | Dev CLI — extends cli, adds Xdebug, OPcache off |

## Test plan

- [x] `ianmgg/php83fpm:latest` builds successfully (amd64, local)
- [x] `ianmgg/php83fpm:cli` builds successfully (amd64, local)
- [x] `ianmgg/php83fpm:dev` builds successfully (amd64, local)
- [x] `ianmgg/php83fpm:cli-dev` builds successfully (amd64, local)
- [ ] Trigger `Docker Image CI - FPM` workflow manually to build and push amd64+arm64 to Docker Hub
- [ ] Smoke test against a Flarum instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)