### PR TITLE
feat: add pdo_pgsql to fpm 8.3 images

### DIFF
--- a/fpm/8.3/Dockerfile.apache
+++ b/fpm/8.3/Dockerfile.apache
@@ -41,7 +41,8 @@ RUN apt-get -y update && apt-get -y upgrade && ACCEPT_EULA=Y && apt-get install 
     redis-tools \
     vim \
     liblz4-dev \
-    libzstd-dev && \
+    libzstd-dev \
+    libpq-dev && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -51,6 +52,7 @@ RUN docker-php-ext-install gd
 RUN docker-php-ext-install calendar
 RUN docker-php-ext-install intl
 RUN docker-php-ext-install pdo_mysql
+RUN docker-php-ext-install pdo_pgsql
 RUN docker-php-ext-install xml
 RUN docker-php-ext-install zip
 RUN docker-php-ext-install exif

--- a/fpm/8.3/Dockerfile.cli
+++ b/fpm/8.3/Dockerfile.cli
@@ -40,7 +40,8 @@ RUN apt-get -y update && apt-get -y upgrade && ACCEPT_EULA=Y && apt-get install 
     redis-tools \
     vim \
     liblz4-dev \
-    libzstd-dev && \
+    libzstd-dev \
+    libpq-dev && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -50,6 +51,7 @@ RUN docker-php-ext-install gd
 RUN docker-php-ext-install calendar
 RUN docker-php-ext-install intl
 RUN docker-php-ext-install pdo_mysql
+RUN docker-php-ext-install pdo_pgsql
 RUN docker-php-ext-install xml
 RUN docker-php-ext-install zip
 RUN docker-php-ext-install exif


### PR DESCRIPTION
## Summary
- Adds `libpq-dev` apt package to both `Dockerfile.apache` and `Dockerfile.cli` in `fpm/8.3`
- Installs `pdo_pgsql` PHP extension in both images
- Dev variants inherit from these base images and pick up the extension automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)